### PR TITLE
Improve data handling and validation for surf and hetero

### DIFF
--- a/nsbtools/eigen.py
+++ b/nsbtools/eigen.py
@@ -288,6 +288,10 @@ class EigenSolver(Solver):
             if an invalid method is specified, or if the `mass` matrix is not provided when
             required.
         """
+        data = np.asarray(data)
+        emodes = np.asarray(emodes)
+        if isinstance(mass, list):
+            mass = np.array(mass)
 
         if np.shape(data)[0] != np.shape(emodes)[0]:
             raise ValueError(f"The number of elements in `data` ({np.shape(data)[0]}) must match "
@@ -385,6 +389,8 @@ class EigenSolver(Solver):
         """
         data = np.asarray(data)
         emodes = np.asarray(emodes)
+        if isinstance(mass, list):
+            mass = np.array(mass)
 
         if metric not in ["pearsonr", "mse"]:
             raise ValueError(f"Invalid metric '{metric}'; must be 'pearsonr' or 'mse'.")
@@ -733,8 +739,7 @@ def check_orthonorm_modes(
     decomposition, wave simulation), this function serves to ensure the validity of any calculated
     or provided eigenmodes.
     """
-    if isinstance(emodes, list):
-        emodes = np.array(emodes)
+    emodes = np.asarray(emodes)
     if isinstance(mass, list):
         mass = np.array(mass)
 
@@ -758,8 +763,7 @@ def standardize_modes(emodes: Union[np.ndarray, List[List[float]]]) -> np.ndarra
         The standardized eigenmodes array of shape (n_verts, n_modes), with the first element of
         each mode set to be positive.
     """
-    if isinstance(emodes, list):
-        emodes = np.array(emodes)
+    emodes = np.asarray(emodes)
 
     # Find the sign of the first non-zero element in each column
     signs = np.sign(emodes[np.argmax(emodes != 0, axis=0), np.arange(emodes.shape[1])])

--- a/nsbtools/eigen.py
+++ b/nsbtools/eigen.py
@@ -663,9 +663,9 @@ def check_surf(surf: trimesh.Trimesh) -> None:
                          'vertices (i.e., not part of any face).')
 
     # Check if the mesh is contiguous
-    components = surf.split(only_watertight=False)
-    if len(components) != 1:
-        raise ValueError(f'Surface mesh is not contiguous: {len(components)} connected components '
+    n_components = surf.body_count
+    if n_components != 1:
+        raise ValueError(f'Surface mesh is not contiguous: {n_components} connected components '
                          'found.')
 
 def check_hetero(hetero: np.ndarray, r: float, gamma: float) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "scipy>=1.10.1",
     "surfplot>=0.2.0",
     "trimesh>=4.8.1",
-    "networkx>=3.2.1",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -171,7 +171,7 @@ def test_solve_lumped_mass(solve_modes, surf_medmask_hetero):
 
     assert np.allclose(abs(emodes), abs(emodes_lumped), atol=1e-3), \
         'Lumped mass modes do not approximately match original modes.'
-    for i in range(1, solver.nmodes):
+    for i in range(1, solver.n_modes):
         assert np.corrcoef(emodes[:, i], emodes_lumped[:, i])[0, 1] > 0.99, \
             'Lumped mass modes do not match original modes.'
 
@@ -180,10 +180,10 @@ def test_solutions(solve_modes):
     evals = solver.evals
 
     assert emodes.shape == (solver.n_verts,
-                           solver.nmodes), (f'Eigenmodes have shape {emodes.shape}, should be '
-                                            f'{(solver.n_verts, solver.nmodes)}.')
-    assert len(evals) == solver.nmodes, (f'Eigenvalues has length {len(evals)}, should be '
-                                         f'{solver.nmodes}.')
+                           solver.n_modes), (f'Eigenmodes have shape {emodes.shape}, should be '
+                                            f'{(solver.n_verts, solver.n_modes)}.')
+    assert len(evals) == solver.n_modes, (f'Eigenvalues has length {len(evals)}, should be '
+                                         f'{solver.n_modes}.')
     assert np.all(np.diff(evals) > 0), 'Eigenvalues are not sorted in descending order.'
 
 def test_constant_mode1(solve_modes):
@@ -213,12 +213,12 @@ def test_warn_orthonorm(solve_modes):
 def test_decompose_eigenmodes(solve_modes):
     solver, emodes = solve_modes
 
-    for i in range(solver.nmodes):
+    for i in range(solver.n_modes):
         data = emodes[:, i]  # Use an eigenmode as data
         beta = solver.decompose(data, emodes, mass=solver.mass)
 
         # The mode should load onto only itself due to orthogonality
-        beta_expected = np.zeros((solver.nmodes, 1))
+        beta_expected = np.zeros((solver.n_modes, 1))
         beta_expected[i, 0] = 1
         assert np.allclose(beta, beta_expected, atol=1e-4), f'Decomposition of mode {i+1} failed.'
 
@@ -270,7 +270,7 @@ def gen_eigenmap(solve_modes):
     # Use randomly weighted sums of modes to generate maps
     n_maps = 3
     np.random.seed(0)
-    weights = np.random.normal(loc=0, scale=0.5, size=(solver.nmodes, n_maps))
+    weights = np.random.normal(loc=0, scale=0.5, size=(solver.n_modes, n_maps))
     eigenmaps = emodes @ weights
 
     return solver, emodes, weights, eigenmaps

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -27,7 +27,7 @@ def test_invalid_surf():
     with pytest.raises(ValueError, match="Surface must be a .*"):
         EigenSolver([1,2,3])
 
-def test_surf_unreferenced_verts():    
+def test_surf_unreferenced_verts():
     # Create an invalid mesh with unreferenced vertices
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [2, 2, 2]])  # Last vertex unreferenced
     faces = np.array([[0, 1, 2], [0, 2, 3]])  # Only uses first 4 vertices, vertex 4 is unreferenced
@@ -39,7 +39,7 @@ def test_surf_unreferenced_verts():
     with pytest.raises(ValueError, match="Surface mesh contains .* unreferenced vertices"):
         check_surf(invalid_mesh)
 
-def test_surf_not_contiguous():   
+def test_surf_not_contiguous():
     # Create two separate triangles (disconnected components)
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [2, 0, 0], [3, 0, 0], [2, 1, 0]])
     faces = np.array([[0, 1, 2], [3, 4, 5]])  # Two separate triangles

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -53,12 +53,27 @@ def test_nan_inf_hetero(surf_medmask_hetero):
     with pytest.raises(ValueError, match="`hetero` must not contain NaNs or Infs."):
         EigenSolver(surfpath, hetero=hetero)
 
-def test_list_hetero(surf_medmask_hetero):
-    surfpath, _, hetero = surf_medmask_hetero
+def test_nan_inf_hetero_medmask(surf_medmask_hetero):
+    # Inject NaN/Inf at a cortical vertex (should raise error)
+    surfpath, medmask, hetero = surf_medmask_hetero
+    cortical_vertex = np.where(medmask)[0][0]
+    print(cortical_vertex)
+    hetero[cortical_vertex] = np.nan
+    with pytest.raises(ValueError, match="`hetero` must not contain NaNs or Infs."):
+        EigenSolver(surfpath, hetero=hetero)
+    hetero[cortical_vertex] = np.inf
+    with pytest.raises(ValueError, match="`hetero` must not contain NaNs or Infs."):
+        EigenSolver(surfpath, hetero=hetero)
 
-    list_hetero = hetero.tolist()
-    with pytest.raises(ValueError, match="`hetero` must be a numpy array or None."):
-        EigenSolver(surfpath, hetero=list_hetero)
+def test_nan_inf_hetero_medmask_ignored(surf_medmask_hetero):
+    # Inject NaN/Inf at a medial vertex (should be ignored)
+    surfpath, medmask, hetero = surf_medmask_hetero
+    medial_vertex = np.where(~medmask)[0][0]
+    print(medial_vertex)
+    hetero[medial_vertex] = np.nan
+    EigenSolver(surfpath, medmask=medmask, hetero=hetero)
+    hetero[medial_vertex] = np.inf  
+    EigenSolver(surfpath, medmask=medmask, hetero=hetero)
 
 def test_init_invalid_wave_speed(surf_medmask_hetero):
     surfpath, medmask, hetero = surf_medmask_hetero


### PR DESCRIPTION
- Created new validation function `check_surf` that checks for unreferenced vertices as well as non-contiguous surfaces. This check is called within `read_surf` and `mask_surf`.
- Only validate cortical data on `hetero`. NaNs and Infs on the medial wall are allowed.
- Improve input data handling
- Replace `Trismesh.split` with `Trimesh.body_count` and remove `networkx` dependency
- Add new test functions based on these new changes